### PR TITLE
AND-348: Keep GOV.UK reCAPTCHA field id stable on errors

### DIFF
--- a/app/helpers/katalyst/google_apis/govuk_form_builder.rb
+++ b/app/helpers/katalyst/google_apis/govuk_form_builder.rb
@@ -57,7 +57,7 @@ module Katalyst
 
         def options
           {
-            id:    field_id(link_errors: true),
+            id:    field_id,
             class: classes,
             aria:  { describedby: combine_references(error_id) },
           }

--- a/spec/helpers/katalyst/google_apis/govuk_form_builder_spec.rb
+++ b/spec/helpers/katalyst/google_apis/govuk_form_builder_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Katalyst::GoogleApis::GOVUKFormBuilder do
       "data-recaptcha-site-key-value" => "test-site-key",
       "token_name"                    => "quotation[recaptcha_token]",
     )
+    expect(recaptcha["id"]).to eq("quotation-recaptcha-token-field")
+    expect(recaptcha["class"]).to eq("govuk-recaptcha")
   end
 
   context "with errors" do
@@ -60,7 +62,9 @@ RSpec.describe Katalyst::GoogleApis::GOVUKFormBuilder do
 
       expect(form_group["class"]).to include("govuk-form-group--error")
       expect(error_message).to be_present
+      expect(recaptcha["id"]).to eq("quotation-recaptcha-token-field")
       expect(recaptcha["class"]).to include("govuk-recaptcha--error")
+      expect(recaptcha["aria-describedby"]).to eq("quotation-recaptcha-token-error")
     end
   end
 end


### PR DESCRIPTION
Avoid changing the reCAPTCHA wrapper id when validation errors are
 rendered, so Turbo morphing does not leave duplicate widgets in the DOM.